### PR TITLE
Added other audio codec options for downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ services:
       - ./library:/library
     environment:
       # --- Basic Configuration ---
-      - AUDIO_FORMAT=m4a          # m4a or mp3
+      - AUDIO_FORMAT=m4a          # one of [flac, alac, wav, aiff, opus, vorbis, aac, mp4a, mp3, ac4, eac3, ac3, dts]
       - QUALITY=0                 # For MP3, VBR quality (0=best, 9=worst)
       - CONCURRENCY=4             # Number of parallel downloads
       - WRITE_M3U=1               # 1=Create M3U8 playlists, 0=disable

--- a/compose.yml
+++ b/compose.yml
@@ -6,7 +6,7 @@ services:
     # user: "${UID:-1000}:${GID:-1000}"
     environment:
       # --- Basic Configuration ---
-      - AUDIO_FORMAT=m4a # m4a or mp3
+      - AUDIO_FORMAT=m4a # one of [flac, alac, wav, aiff, opus, vorbis, aac, mp4a, mp3, ac4, eac3, ac3, dts]
       - QUALITY=0 # For MP3, VBR quality (0=best, 9=worst)
       - CONCURRENCY=4 # Number of parallel downloads
       - WRITE_M3U=1 # 1=Create M3U8 playlists, 0=disable

--- a/ytm_takeout_downloader.py
+++ b/ytm_takeout_downloader.py
@@ -767,7 +767,7 @@ def main() -> int:
     )
     ap.add_argument("takeout_path", help="Path to folder containing Takeout JSON and/or CSV files.")
     ap.add_argument("-o", "--output-dir", default="/library", help="Output library directory.")
-    ap.add_argument("--audio-format", default="m4a", choices=["m4a", "mp3"], help="Output audio format.")
+    ap.add_argument("--audio-format", default="m4a", choices=["flac", "alac", "wav", "aiff", "opus", "vorbis", "aac", "mp4a", "mp3", "ac4", "eac3", "ac3", "dts"], help="Output audio format.")
     ap.add_argument("--quality", default="0", help="For MP3, VBR quality from 0 (best) to 9 (worst).")
     ap.add_argument("--concurrency", type=int, default=2, help="Number of parallel downloads.")
     ap.add_argument("--prefer-youtube-music", action="store_true", help="Rewrite video URLs to music.youtube.com for better metadata.")


### PR DESCRIPTION
The audio codecs include: [flac, alac, wav, aiff, opus, vorbis, aac, mp4a, mp3, ac4, eac3, ac3, dts] This list of codecs was taken from [yt-dlp Readme](https://github.com/yt-dlp/yt-dlp/?tab=readme-ov-file#sorting-formats)